### PR TITLE
Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: The targets to install
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: arrow-right


### PR DESCRIPTION
github is complaining about actions using node 12 with the following warning:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: ATiltedTree/setup-rust@v1
```

This is an attempt to fix it.